### PR TITLE
[Feat#48] 유형분류, 템플릿 관련 API 로직 수정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -53,6 +53,9 @@ dependencies {
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.2'
+	implementation 'org.hibernate.orm:hibernate-core:6.3.1.Final'
+	implementation 'org.hibernate.common:hibernate-commons-annotations:6.0.6.Final'
+
 
 
 }

--- a/src/main/java/cap/math/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/cap/math/apiPayload/code/status/ErrorStatus.java
@@ -36,6 +36,7 @@ public enum ErrorStatus implements BaseErrorCode {
 
     // 기타 에러
     JSON_PARSING_ERROR(HttpStatus.BAD_REQUEST, "JSON4001", "JSON 파싱이 잘못되었습니다."),
+    TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "TYPE4001", "존재하지 않는 수학문제 유형입니다."),
 
     ;
 

--- a/src/main/java/cap/math/apiPayload/code/status/ErrorStatus.java
+++ b/src/main/java/cap/math/apiPayload/code/status/ErrorStatus.java
@@ -37,6 +37,7 @@ public enum ErrorStatus implements BaseErrorCode {
     // 기타 에러
     JSON_PARSING_ERROR(HttpStatus.BAD_REQUEST, "JSON4001", "JSON 파싱이 잘못되었습니다."),
     TYPE_NOT_FOUND(HttpStatus.NOT_FOUND, "TYPE4001", "존재하지 않는 수학문제 유형입니다."),
+    TEMPLATE_NOT_FOUND(HttpStatus.NOT_FOUND, "TEMPLATE4001", "존재하지 않는 수학문제 유형입니다."),
 
     ;
 

--- a/src/main/java/cap/math/controller/MathController.java
+++ b/src/main/java/cap/math/controller/MathController.java
@@ -64,9 +64,20 @@ public class MathController {
         return ApiResponse.onSuccess(templateList);
     }
 
+    @PostMapping(value="/parameters/{mathId}")
+    @Operation(summary="파라미터 추출 API",
+            description="LLM으로부터 사용자가 선택한 템플릿에 맞는 파라미터를 추출합니다.")
+    public ApiResponse<MathResponseDTO.createParameterDto> createParameter(@AuthenticationPrincipal String userName, @PathVariable Long mathId, @RequestParam Long templateId){
+        User user=userRepository.findByName(userName)
+                .orElseThrow(()-> new TempHandler(USER_NOT_FOUND));
+        MathResponseDTO.createParameterDto parameter= templateService.createParameter(mathId, templateId);
+
+        return ApiResponse.onSuccess(parameter);
+    }
+
     @GetMapping(value="/quiz/{mathId}")
     @Operation(summary="문제 풀기 API",
-            description="수학문제 ID 입력 시, JSON 데이터을 추출합니다.")
+            description="수학문제 ID 입력 시, JSON 데이터를 추출합니다.")
     public ApiResponse<MathResponseDTO.crerateMathDto> getMath(@AuthenticationPrincipal String userName,@PathVariable Long mathId){
         User user=userRepository.findByName(userName)
                 .orElseThrow(()-> new TempHandler(USER_NOT_FOUND));

--- a/src/main/java/cap/math/controller/MathController.java
+++ b/src/main/java/cap/math/controller/MathController.java
@@ -9,6 +9,7 @@ import cap.math.dto.math.MathResponseDTO;
 import cap.math.repository.MathRepository;
 import cap.math.repository.UserRepository;
 import cap.math.service.MathService.MathService;
+import cap.math.service.TemplateService.TemplateService;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -29,6 +30,7 @@ public class MathController {
     private final MathService mathService;
     private final UserRepository userRepository;
     private final MathRepository mathRepository;
+    private final TemplateService templateService;
 
     @PostMapping(value="/images", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary="사진 촬영 API",
@@ -39,6 +41,27 @@ public class MathController {
         MathResponseDTO.crerateMathDto math= mathService.createMath(user,"image",image);
 
         return ApiResponse.onSuccess(math);
+    }
+
+    @PostMapping(value="/types",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    @Operation(summary="유형 분류 API",
+            description="수학문제 사진 업로드 시, GPT로부터 문제의 유형 번호를 받아옵니다.")
+    public ApiResponse<MathResponseDTO.crerateMathTypeDto> createMathType(@AuthenticationPrincipal String userName, @RequestParam("imageFile") MultipartFile image){
+        User user=userRepository.findByName(userName)
+                .orElseThrow(()-> new TempHandler(USER_NOT_FOUND));
+        MathResponseDTO.crerateMathTypeDto math= mathService.createMathType(user,"image",image);
+
+        return ApiResponse.onSuccess(math);
+    }
+    @GetMapping(value="/templates")
+    @Operation(summary="컨텐츠 리스트 조회 API",
+            description="문제 유형을 입력하면, 가능한 컨텐츠 리스트를 보여줍니다.")
+    public ApiResponse<MathResponseDTO.templateDto> getTemplates(@AuthenticationPrincipal String userName, @RequestParam String typeName){
+        User user=userRepository.findByName(userName)
+                .orElseThrow(()-> new TempHandler(USER_NOT_FOUND));
+        MathResponseDTO.templateDto templateList= templateService.getTemplateList(typeName);
+
+        return ApiResponse.onSuccess(templateList);
     }
 
     @GetMapping(value="/quiz/{mathId}")

--- a/src/main/java/cap/math/controller/MathController.java
+++ b/src/main/java/cap/math/controller/MathController.java
@@ -67,12 +67,12 @@ public class MathController {
     @PostMapping(value="/parameters/{mathId}")
     @Operation(summary="파라미터 추출 API",
             description="LLM으로부터 사용자가 선택한 템플릿에 맞는 파라미터를 추출합니다.")
-    public ApiResponse<MathResponseDTO.createParameterDto> createParameter(@AuthenticationPrincipal String userName, @PathVariable Long mathId, @RequestParam Long templateId){
+    public ApiResponse<String> createParameter(@AuthenticationPrincipal String userName, @PathVariable Long mathId, @RequestParam Long templateId){
         User user=userRepository.findByName(userName)
                 .orElseThrow(()-> new TempHandler(USER_NOT_FOUND));
-        MathResponseDTO.createParameterDto parameter= templateService.createParameter(mathId, templateId);
+        String parameter= templateService.createParameter(mathId, templateId);
 
-        return ApiResponse.onSuccess(parameter);
+         return ApiResponse.onSuccess(parameter);
     }
 
     @GetMapping(value="/quiz/{mathId}")

--- a/src/main/java/cap/math/controller/MathController.java
+++ b/src/main/java/cap/math/controller/MathController.java
@@ -45,7 +45,7 @@ public class MathController {
 
     @PostMapping(value="/types",consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
     @Operation(summary="유형 분류 API",
-            description="수학문제 사진 업로드 시, GPT로부터 문제의 유형 번호를 받아옵니다.")
+            description="수학문제 사진 업로드 시, GPT로부터 문제의 유형 번호와 문제 텍스트를 받아옵니다.")
     public ApiResponse<MathResponseDTO.crerateMathTypeDto> createMathType(@AuthenticationPrincipal String userName, @RequestParam("imageFile") MultipartFile image){
         User user=userRepository.findByName(userName)
                 .orElseThrow(()-> new TempHandler(USER_NOT_FOUND));
@@ -67,10 +67,10 @@ public class MathController {
     @PostMapping(value="/parameters/{mathId}")
     @Operation(summary="파라미터 추출 API",
             description="LLM으로부터 사용자가 선택한 템플릿에 맞는 파라미터를 추출합니다.")
-    public ApiResponse<String> createParameter(@AuthenticationPrincipal String userName, @PathVariable Long mathId, @RequestParam Long templateId){
+    public ApiResponse<MathResponseDTO.createParameterDto> createParameter(@AuthenticationPrincipal String userName, @PathVariable Long mathId, @RequestParam Long templateId){
         User user=userRepository.findByName(userName)
                 .orElseThrow(()-> new TempHandler(USER_NOT_FOUND));
-        String parameter= templateService.createParameter(mathId, templateId);
+        MathResponseDTO.createParameterDto parameter= mathService.createParameter(mathId, templateId);
 
          return ApiResponse.onSuccess(parameter);
     }

--- a/src/main/java/cap/math/domain/MathType.java
+++ b/src/main/java/cap/math/domain/MathType.java
@@ -18,7 +18,7 @@ public class MathType extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    private String type_name;
+    private String typeName;
 
     //@Column(length = 5000)
     @Lob

--- a/src/main/java/cap/math/domain/Template.java
+++ b/src/main/java/cap/math/domain/Template.java
@@ -18,6 +18,12 @@ public class Template extends BaseEntity {
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
+    private String templateName;
+
+    private Boolean isPossible;
+
+    private String templateImage;
+
     //@Column(length = 5000)
     @Lob
     @Column(columnDefinition = "TEXT")

--- a/src/main/java/cap/math/dto/math/MathResponseDTO.java
+++ b/src/main/java/cap/math/dto/math/MathResponseDTO.java
@@ -21,6 +21,35 @@ public class MathResponseDTO {
 
 
     }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class crerateMathTypeDto{
+        private Long mathId;
+        private String image;
+        private mathTypeDto mathTypeDto;
+    }
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class mathTypeDto{
+        private String problem;
+        private String type_name;
+        private Integer answer;
+        private String extractedImage;
+    }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class templateDto{
+        private List<Long> templateIds;
+    }
+
+
 
     @Builder
     @Getter

--- a/src/main/java/cap/math/dto/math/MathResponseDTO.java
+++ b/src/main/java/cap/math/dto/math/MathResponseDTO.java
@@ -46,14 +46,27 @@ public class MathResponseDTO {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class templateDto{
-        private List<Long> templateIds;
+        private List<singleTemplateDto> templates;
     }
+
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class singleTemplateDto{
+        private Long templateId;
+        private String templateName;
+        private Boolean isPossible;
+        private String templateImage;
+    }
+
+
     @Builder
     @Getter
     @NoArgsConstructor
     @AllArgsConstructor
     public static class createParameterDto{
-        private String gpt;
+        private String deploy;
     }
 
 

--- a/src/main/java/cap/math/dto/math/MathResponseDTO.java
+++ b/src/main/java/cap/math/dto/math/MathResponseDTO.java
@@ -48,7 +48,13 @@ public class MathResponseDTO {
     public static class templateDto{
         private List<Long> templateIds;
     }
-
+    @Builder
+    @Getter
+    @NoArgsConstructor
+    @AllArgsConstructor
+    public static class createParameterDto{
+        private String gpt;
+    }
 
 
     @Builder

--- a/src/main/java/cap/math/repository/MathTypeRepository.java
+++ b/src/main/java/cap/math/repository/MathTypeRepository.java
@@ -1,0 +1,13 @@
+package cap.math.repository;
+
+import cap.math.domain.Math;
+import cap.math.domain.MathType;
+import cap.math.domain.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface MathTypeRepository extends JpaRepository<MathType, Long> {
+    Boolean existsByTypeName(String type_name);
+    Optional<MathType> findByTypeName(String name);
+}

--- a/src/main/java/cap/math/repository/ProbExtractImageRepository.java
+++ b/src/main/java/cap/math/repository/ProbExtractImageRepository.java
@@ -1,0 +1,8 @@
+package cap.math.repository;
+
+import cap.math.domain.MathType;
+import cap.math.domain.ProbExtractImage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ProbExtractImageRepository extends JpaRepository<ProbExtractImage, Long> {
+}

--- a/src/main/java/cap/math/repository/TemplateRepository.java
+++ b/src/main/java/cap/math/repository/TemplateRepository.java
@@ -1,0 +1,7 @@
+package cap.math.repository;
+
+import cap.math.domain.Template;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface TemplateRepository extends JpaRepository<Template, Long> {
+}

--- a/src/main/java/cap/math/repository/UnitTemplateMappingRepository.java
+++ b/src/main/java/cap/math/repository/UnitTemplateMappingRepository.java
@@ -1,0 +1,11 @@
+package cap.math.repository;
+
+import cap.math.domain.MathType;
+import cap.math.domain.UnitTemplateMapping;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+public interface UnitTemplateMappingRepository extends JpaRepository<UnitTemplateMapping, Long> {
+    List<UnitTemplateMapping> findAllByMathType(MathType mathType);
+}

--- a/src/main/java/cap/math/service/MathService/MathService.java
+++ b/src/main/java/cap/math/service/MathService/MathService.java
@@ -14,6 +14,6 @@ public interface MathService {
     MathResponseDTO.crerateMathDto getNew(Long userId);
     String getSimpleResponse(String prompt, String directory, MultipartFile image);
     MathResponseDTO.crerateMathTypeDto createMathType(User user, String directory, MultipartFile image);
-
+    MathResponseDTO.createParameterDto createParameter(Long mathId, Long templateId);
 
 }

--- a/src/main/java/cap/math/service/MathService/MathService.java
+++ b/src/main/java/cap/math/service/MathService/MathService.java
@@ -13,6 +13,7 @@ public interface MathService {
     MathResponseDTO.getAnswerDto getRandom(Long mathId);
     MathResponseDTO.crerateMathDto getNew(Long userId);
     String getSimpleResponse(String prompt, String directory, MultipartFile image);
+    MathResponseDTO.crerateMathTypeDto createMathType(User user, String directory, MultipartFile image);
 
 
 }

--- a/src/main/java/cap/math/service/MathService/MathServiceImpl.java
+++ b/src/main/java/cap/math/service/MathService/MathServiceImpl.java
@@ -25,10 +25,8 @@ import org.springframework.web.client.RestTemplate;
 import org.springframework.web.multipart.MultipartFile;
 
 import java.time.LocalDateTime;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.Objects;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static cap.math.apiPayload.code.status.ErrorStatus.*;
 
@@ -102,10 +100,10 @@ public class MathServiceImpl implements MathService {
 
 
         String imageUrl= s3Manager.uploadFile(directory, image);
-        String typePrompt=generateTypePrompt(imageUrl);
+        String typePrompt=generateTypePrompt();
         String response;
         try{
-            response = callOpenAI(typePrompt, imageUrl, 200);
+            response = callOpenAIV2(typePrompt, imageUrl, 200);
         } catch (JsonProcessingException e) {
             throw new TempHandler(JSON_PARSING_ERROR);
         }
@@ -198,23 +196,27 @@ public class MathServiceImpl implements MathService {
     }
 
 
-    public String generateTypePrompt(String imageUrl) {
+    public String generateTypePrompt() {
         StringBuilder prompt = new StringBuilder();
-        prompt.append("이미지 주소: ").append(imageUrl).append("\n")
-                .append("이 이미지는 초등학교 1학년 수준의 수학 문제 사진이야.\n")
-                .append("1. 먼저 이미지를 자세히 보고, 글자뿐 아니라 그림(사과 개수 등)으로 표현된 수량이 있으면 텍스트 변환해서 '4+5'처럼 이 형식으로 읽어줘.\n")
-                .append("2. 문제의 핵심 연산이 덧셈인지 뺄셈인지 판단하고, 문제의 수식 형태(예: 2+3)를 명확히 구성해. 숫자 제발 다시 정확하게 봐. 텍스트 추출 잘해.\n")
+        List<String> gptList = mathTypeRepository.findAll()
+                .stream()
+                .map(MathType::getGpt) // 각 객체에서 gpt 필드 추출
+                .collect(Collectors.toList());
+        prompt.append("이 이미지는 초등학교 1학년 수준의 수학 문제 사진이야.\n")
+                .append("1. 먼저 이미지를 자세히 보고, 문제를 스크립트 변환해줘. 문제 텍스트는 problem에 붙여줘.\n")
+                .append("2. 문제 텍스트와 문제 이미지를 보고 내가 보낸 유형 리스트 중에 해당하는 유형 이름을 추출해서 typeName에 붙여줘.\n")
                 .append("3. JSON은 반드시 아래 예시 형식으로 출력하고, 설명이나 추가 문장은 절대 쓰지 마.\n")
-                .append("4. 'entity'는 항상 'apple'로 고정.\n")
-                .append("5. 'wrongAnswers'는 정답과 1~2 차이 나는 숫자 두 개로 만들어.\n\n")
+                .append("4. 문제 정답도 구해주고 answer에 붙여줘.\n")
+                .append("5. 그리고 이 문제의 학년, 학기, 단원 제목도 알려줘.\n\n")
+                .append("6. 유형 리스트 보내줄게.\n") .append(gptList).append("\n\n")
                 .append("출력 형식 예시:\n")
                 .append("{\n")
                 .append("  \"problem\": \"2+3\",\n")
-                .append("  \"entity\": \"apple\",\n")
-                .append("  \"count1\": 2,\n")
-                .append("  \"count2\": 3,\n")
+                .append("  \"typeName\": \"apple\",\n")
                 .append("  \"answer\": 5,\n")
-                .append("  \"typeName\": 3,\n")
+                .append("  \"학년\": 3,\n")
+                .append("  \"학기\": 2,\n")
+                .append("  \"단원\": 1단원,\n")
                 .append("}\n\n")
                 .append("지금부터 이미지를 분석하고 위 JSON만 정확히 출력해. 그 외 설명은 쓰지 마.");
 
@@ -242,6 +244,62 @@ public class MathServiceImpl implements MathService {
                 .append("지금부터 이미지를 분석하고 위 JSON만 정확히 출력해. 그 외 설명은 쓰지 마.");
 
         return prompt.toString();
+    }
+
+    public String callOpenAIV2(String prompt, String imageUrl, int maxTokens) throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(gptConfig.getSecretKey());
+
+        // OpenAI 메시지 구성
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", gptConfig.getModel());
+
+        List<Map<String, Object>> contentList = new ArrayList<>();
+
+        // 1. 텍스트 프롬프트
+        Map<String, Object> textContent = new HashMap<>();
+        textContent.put("type", "text");
+        textContent.put("text", prompt);
+        contentList.add(textContent);
+
+        // 2. 이미지 URL (GPT가 실제로 인식할 수 있도록 전달)
+        if (imageUrl != null && !imageUrl.isEmpty()) {
+            Map<String, Object> imageContent = new HashMap<>();
+            imageContent.put("type", "image_url");
+
+            Map<String, String> imageUrlMap = new HashMap<>();
+            imageUrlMap.put("url", imageUrl); // 👈 실제 이미지 URL
+            imageContent.put("image_url", imageUrlMap);
+
+            contentList.add(imageContent);
+        }
+
+        // user 메시지 구성
+        Map<String, Object> userMessage = new HashMap<>();
+        userMessage.put("role", "user");
+        userMessage.put("content", contentList);
+
+        List<Map<String, Object>> messages = new ArrayList<>();
+        messages.add(userMessage);
+
+        requestBody.put("messages", messages);
+        requestBody.put("temperature", 0.3);
+        requestBody.put("max_tokens", maxTokens);
+
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    "https://api.openai.com/v1/chat/completions",
+                    HttpMethod.POST,
+                    entity,
+                    String.class
+            );
+            return response.getBody();
+        } catch (Exception e) {
+            return "Error: " + e.getMessage();
+        }
     }
 
 
@@ -324,7 +382,6 @@ public class MathServiceImpl implements MathService {
         Map<String, Object> requestBody = new HashMap<>();
         requestBody.put("model", "gpt-4o");
 
-        // ✅ messages에 text + image_url 모두 포함
         Map<String, Object> userMessage = new HashMap<>();
         userMessage.put("role", "user");
         userMessage.put("content", List.of(

--- a/src/main/java/cap/math/service/MathService/MathServiceImpl.java
+++ b/src/main/java/cap/math/service/MathService/MathServiceImpl.java
@@ -41,6 +41,7 @@ public class MathServiceImpl implements MathService {
     private final MathConverter mathConverter;
     private final MathTypeRepository mathTypeRepository;
     private final ProbExtractImageRepository  probExtractImageRepository;
+    private final TemplateRepository templateRepository;
 
     @Override
     @Transactional
@@ -103,7 +104,8 @@ public class MathServiceImpl implements MathService {
         String typePrompt=generateTypePrompt();
         String response;
         try{
-            response = callOpenAIV2(typePrompt, imageUrl, 200);
+            response = callOpenAIV2(typePrompt, imageUrl, 500);
+            System.out.println(response);
         } catch (JsonProcessingException e) {
             throw new TempHandler(JSON_PARSING_ERROR);
         }
@@ -114,6 +116,7 @@ public class MathServiceImpl implements MathService {
         }catch (Exception e) {
             throw new TempHandler(_BAD_REQUEST);
         }
+
         MathType mathType=mathTypeRepository.findByTypeName(typeDto.getType_name())
                 .orElseThrow(() -> new TempHandler(TYPE_NOT_FOUND));
 
@@ -204,19 +207,17 @@ public class MathServiceImpl implements MathService {
                 .collect(Collectors.toList());
         prompt.append("이 이미지는 초등학교 1학년 수준의 수학 문제 사진이야.\n")
                 .append("1. 먼저 이미지를 자세히 보고, 문제를 스크립트 변환해줘. 문제 텍스트는 problem에 붙여줘.\n")
-                .append("2. 문제 텍스트와 문제 이미지를 보고 내가 보낸 유형 리스트 중에 해당하는 유형 이름을 추출해서 typeName에 붙여줘.\n")
+                .append("2. 문제 텍스트와 문제 이미지를 보고 내가 보낸 유형 리스트 중에 해당하는 유형 이름을 추출해서 type_name에 붙여줘.\n")
                 .append("3. JSON은 반드시 아래 예시 형식으로 출력하고, 설명이나 추가 문장은 절대 쓰지 마.\n")
-                .append("4. 문제 정답도 구해주고 answer에 붙여줘.\n")
-                .append("5. 그리고 이 문제의 학년, 학기, 단원 제목도 알려줘.\n\n")
-                .append("6. 유형 리스트 보내줄게.\n") .append(gptList).append("\n\n")
+                .append("4. 문제 정답도 구해주고 answer에 붙여줘. 만약 정답이 왼쪽 오른쪽 등으로 나온다면 우상향 방향을 기준으로 순서대로 번호로 답해줘.\n")
+                .append("5. 그리고 이 문제에 사진이 있다면 사진 url을 extractedImage에 저장해줘. 만약 없거나 저장할 수 없다면 null로 해.\n\n")
+                .append("6. 유형 리스트 보내줄게. 만약 내가 준 유형 리스트 중에서 이 문제의 유형에 해당하는게 없다면 type_name은 그냥 false로 보내고, 있다면 아래와 같이 JSON 형식으로 답변하면돼.\n") .append(gptList).append("\n\n")
                 .append("출력 형식 예시:\n")
                 .append("{\n")
                 .append("  \"problem\": \"2+3\",\n")
-                .append("  \"typeName\": \"apple\",\n")
+                .append("  \"type_name\": \"apple\",\n")
                 .append("  \"answer\": 5,\n")
-                .append("  \"학년\": 3,\n")
-                .append("  \"학기\": 2,\n")
-                .append("  \"단원\": 1단원,\n")
+                .append("  \"extractedImage\": string,\n")
                 .append("}\n\n")
                 .append("지금부터 이미지를 분석하고 위 JSON만 정확히 출력해. 그 외 설명은 쓰지 마.");
 
@@ -246,6 +247,54 @@ public class MathServiceImpl implements MathService {
         return prompt.toString();
     }
 
+    @Override
+    @Transactional
+    public MathResponseDTO.createParameterDto createParameter(Long mathId, Long templateId){
+
+        Math math=mathRepository.findById(mathId)
+                .orElseThrow(()->new TempHandler(MATH_NOT_FOUND));
+        String typePrompt=generateTemplatePrompt(mathId,templateId);
+        String imageUrl=math.getImage();
+        String response;
+        try{
+            response = callOpenAIV2(typePrompt, imageUrl, 500);
+            System.out.println(response);
+        } catch (JsonProcessingException e) {
+            throw new TempHandler(JSON_PARSING_ERROR);
+        }
+        String extractedContent = extractContent(response);
+        MathResponseDTO.createParameterDto parameterDto = MathResponseDTO.createParameterDto.builder()
+                .deploy(extractedContent)
+                .build();
+
+
+        Template template= templateRepository.findById(templateId)
+                .orElseThrow(()-> new TempHandler(TEMPLATE_NOT_FOUND));
+
+        template.setGpt(parameterDto.getDeploy());
+        templateRepository.save(template);
+
+        return parameterDto;
+
+
+    }
+
+    public String generateTemplatePrompt(Long mathId,Long templateId) {
+        StringBuilder prompt = new StringBuilder();
+        Math math=mathRepository.findById(mathId).orElseThrow(()->new TempHandler(MATH_NOT_FOUND));
+        String mathText=math.getProblem();
+        String mathType=math.getMathType().getTypeName();
+        Template template= templateRepository.findById(templateId).orElseThrow(()->new TempHandler(TEMPLATE_NOT_FOUND));
+        String gpt=template.getGpt();
+
+        prompt.append("문제:").append(mathText).append("\n")
+                .append("유형:").append(mathType).append("\n")
+                .append("1. 문제 텍스트와 유형은 위와 같아. \n")
+                .append("2. 템플릿 어떤식으로 해야하는지 보내줄게.\n").append(gpt).append("\n\n")
+                .append("지금부터 이미지를 분석하고 위 JSON만 정확히 출력해. 그 외 설명은 쓰지 마.");
+
+        return prompt.toString();
+    }
     public String callOpenAIV2(String prompt, String imageUrl, int maxTokens) throws JsonProcessingException {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
@@ -269,7 +318,7 @@ public class MathServiceImpl implements MathService {
             imageContent.put("type", "image_url");
 
             Map<String, String> imageUrlMap = new HashMap<>();
-            imageUrlMap.put("url", imageUrl); // 👈 실제 이미지 URL
+            imageUrlMap.put("url", imageUrl);
             imageContent.put("image_url", imageUrlMap);
 
             contentList.add(imageContent);
@@ -344,8 +393,6 @@ public class MathServiceImpl implements MathService {
             return "Error: " + e.getMessage();
         }
     }
-
-
 
     private String extractContent(String gptResponseJson) {
         try {

--- a/src/main/java/cap/math/service/MathService/MathServiceImpl.java
+++ b/src/main/java/cap/math/service/MathService/MathServiceImpl.java
@@ -7,14 +7,11 @@ import cap.math.aws.s3.AmazonS3Manager;
 
 import cap.math.config.GptConfig;
 import cap.math.converter.MathConverter;
+import cap.math.domain.*;
 import cap.math.domain.Math;
-import cap.math.domain.MathEntity;
-import cap.math.domain.User;
 import cap.math.dto.math.MathRequestDTO;
 import cap.math.dto.math.MathResponseDTO;
-import cap.math.repository.MathEntityRepository;
-import cap.math.repository.MathRepository;
-import cap.math.repository.UuidRepository;
+import cap.math.repository.*;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -44,6 +41,8 @@ public class MathServiceImpl implements MathService {
     private final RestTemplate restTemplate;
     private final MathEntityRepository mathEntityRepository;
     private final MathConverter mathConverter;
+    private final MathTypeRepository mathTypeRepository;
+    private final ProbExtractImageRepository  probExtractImageRepository;
 
     @Override
     @Transactional
@@ -96,6 +95,52 @@ public class MathServiceImpl implements MathService {
                 .build();
 
         return mathResponse;
+    }
+    @Override
+    @Transactional
+    public MathResponseDTO.crerateMathTypeDto createMathType(User user, String directory, MultipartFile image){
+
+
+        String imageUrl= s3Manager.uploadFile(directory, image);
+        String typePrompt=generateTypePrompt(imageUrl);
+        String response;
+        try{
+            response = callOpenAI(typePrompt, 200);
+        } catch (JsonProcessingException e) {
+            throw new TempHandler(JSON_PARSING_ERROR);
+        }
+        ObjectMapper objectMapper=new ObjectMapper();
+        MathResponseDTO.mathTypeDto typeDto;
+        try{
+            typeDto=objectMapper.readValue(extractContent(response), MathResponseDTO.mathTypeDto.class);
+        }catch (Exception e) {
+            throw new TempHandler(_BAD_REQUEST);
+        }
+        MathType mathType=mathTypeRepository.findByTypeName(typeDto.getType_name())
+                .orElseThrow(() -> new TempHandler(TYPE_NOT_FOUND));
+
+        Math math= Math.builder()
+                .image(imageUrl)
+                .user(user)
+                .problem(typeDto.getProblem())
+                .answer(typeDto.getAnswer())
+                .mathType(mathType)
+                .isChecked(false)
+                .build();
+        math=mathRepository.save(math);
+        ProbExtractImage extractImage = ProbExtractImage.builder()
+                .extractImage(typeDto.getExtractedImage())
+                .math(math)
+                .build();
+
+        probExtractImageRepository.save(extractImage);
+        MathResponseDTO.crerateMathTypeDto typeResponse=MathResponseDTO.crerateMathTypeDto.builder()
+                .mathId(math.getId())
+                .image(imageUrl)
+                .mathTypeDto(typeDto)
+                .build();
+
+        return typeResponse;
     }
     @Override
     @Transactional
@@ -153,6 +198,28 @@ public class MathServiceImpl implements MathService {
     }
 
 
+    public String generateTypePrompt(String imageUrl) {
+        StringBuilder prompt = new StringBuilder();
+        prompt.append("이미지 주소: ").append(imageUrl).append("\n")
+                .append("이 이미지는 초등학교 1학년 수준의 수학 문제 사진이야.\n")
+                .append("1. 먼저 이미지를 자세히 보고, 글자뿐 아니라 그림(사과 개수 등)으로 표현된 수량이 있으면 텍스트 변환해서 '4+5'처럼 이 형식으로 읽어줘.\n")
+                .append("2. 문제의 핵심 연산이 덧셈인지 뺄셈인지 판단하고, 문제의 수식 형태(예: 2+3)를 명확히 구성해. 숫자 제발 다시 정확하게 봐. 텍스트 추출 잘해.\n")
+                .append("3. JSON은 반드시 아래 예시 형식으로 출력하고, 설명이나 추가 문장은 절대 쓰지 마.\n")
+                .append("4. 'entity'는 항상 'apple'로 고정.\n")
+                .append("5. 'wrongAnswers'는 정답과 1~2 차이 나는 숫자 두 개로 만들어.\n\n")
+                .append("출력 형식 예시:\n")
+                .append("{\n")
+                .append("  \"problem\": \"2+3\",\n")
+                .append("  \"entity\": \"apple\",\n")
+                .append("  \"count1\": 2,\n")
+                .append("  \"count2\": 3,\n")
+                .append("  \"answer\": 5,\n")
+                .append("  \"typeName\": 3,\n")
+                .append("}\n\n")
+                .append("지금부터 이미지를 분석하고 위 JSON만 정확히 출력해. 그 외 설명은 쓰지 마.");
+
+        return prompt.toString();
+    }
 
     public String generatePrompt(String imageUrl) {
         StringBuilder prompt = new StringBuilder();

--- a/src/main/java/cap/math/service/MathService/MathServiceImpl.java
+++ b/src/main/java/cap/math/service/MathService/MathServiceImpl.java
@@ -53,7 +53,7 @@ public class MathServiceImpl implements MathService {
         String prompt=generatePrompt(imageUrl);
         String response;
         try{
-            response = callOpenAI(prompt, 200);
+            response = callOpenAI(prompt, imageUrl,200);
             System.out.print(response);
         } catch (JsonProcessingException e) {
             throw new TempHandler(JSON_PARSING_ERROR);
@@ -105,7 +105,7 @@ public class MathServiceImpl implements MathService {
         String typePrompt=generateTypePrompt(imageUrl);
         String response;
         try{
-            response = callOpenAI(typePrompt, 200);
+            response = callOpenAI(typePrompt, imageUrl, 200);
         } catch (JsonProcessingException e) {
             throw new TempHandler(JSON_PARSING_ERROR);
         }
@@ -245,7 +245,7 @@ public class MathServiceImpl implements MathService {
     }
 
 
-    public String callOpenAI(String prompt, int maxTokens) throws JsonProcessingException {
+    public String callOpenAI(String prompt, String imageUrl, int maxTokens) throws JsonProcessingException {
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_JSON);
         headers.setBearerAuth(gptConfig.getSecretKey());

--- a/src/main/java/cap/math/service/TemplateService/TemplateService.java
+++ b/src/main/java/cap/math/service/TemplateService/TemplateService.java
@@ -4,5 +4,5 @@ import cap.math.dto.math.MathResponseDTO;
 
 public interface TemplateService {
     MathResponseDTO.templateDto getTemplateList(String typeName);
-    String createParameter(Long mathId, Long templateId);
+
 }

--- a/src/main/java/cap/math/service/TemplateService/TemplateService.java
+++ b/src/main/java/cap/math/service/TemplateService/TemplateService.java
@@ -4,5 +4,5 @@ import cap.math.dto.math.MathResponseDTO;
 
 public interface TemplateService {
     MathResponseDTO.templateDto getTemplateList(String typeName);
-    MathResponseDTO.createParameterDto createParameter(Long mathId, Long templateId);
+    String createParameter(Long mathId, Long templateId);
 }

--- a/src/main/java/cap/math/service/TemplateService/TemplateService.java
+++ b/src/main/java/cap/math/service/TemplateService/TemplateService.java
@@ -4,4 +4,5 @@ import cap.math.dto.math.MathResponseDTO;
 
 public interface TemplateService {
     MathResponseDTO.templateDto getTemplateList(String typeName);
+    MathResponseDTO.createParameterDto createParameter(Long mathId, Long templateId);
 }

--- a/src/main/java/cap/math/service/TemplateService/TemplateService.java
+++ b/src/main/java/cap/math/service/TemplateService/TemplateService.java
@@ -1,0 +1,7 @@
+package cap.math.service.TemplateService;
+
+import cap.math.dto.math.MathResponseDTO;
+
+public interface TemplateService {
+    MathResponseDTO.templateDto getTemplateList(String typeName);
+}

--- a/src/main/java/cap/math/service/TemplateService/TemplateServiceImpl.java
+++ b/src/main/java/cap/math/service/TemplateService/TemplateServiceImpl.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 
 import static cap.math.apiPayload.code.status.ErrorStatus.*;
 import static cap.math.apiPayload.code.status.ErrorStatus._BAD_REQUEST;
+import static cap.math.apiPayload.code.status.ErrorStatus.*;
 
 @Service
 @RequiredArgsConstructor
@@ -38,6 +39,7 @@ public class TemplateServiceImpl implements TemplateService {
     private final TemplateRepository templateRepository;
     private final GptConfig gptConfig;
     private final RestTemplate restTemplate;
+    private final MathService mathService;
 
 
     public MathResponseDTO.templateDto getTemplateList(String typeName){
@@ -46,107 +48,26 @@ public class TemplateServiceImpl implements TemplateService {
 
         List<UnitTemplateMapping> unitTemplateMappings=unitTemplateMappingRepository.findAllByMathType(mathType);
 
-        //UnitTemplateMapping에서 id 리스트를 dto에 담기.
-        List<Long> templateIds = unitTemplateMappings.stream()
-                .map(mapping -> mapping.getTemplate().getId())
+        List<MathResponseDTO.singleTemplateDto> templateDtos = unitTemplateMappings.stream()
+                .map(mapping -> {
+                    Template template = mapping.getTemplate();
+                    return MathResponseDTO.singleTemplateDto.builder()
+                            .templateId(template.getId())
+                            .templateName(template.getTemplateName())
+                            .templateImage(template.getTemplateImage())
+                            .isPossible(template.getIsPossible())// 필요 시 더 추가
+                            .build();
+                })
                 .collect(Collectors.toList());
 
-        // DTO 객체 생성 후 값 세팅
-        MathResponseDTO.templateDto dto =  MathResponseDTO.templateDto.builder()
-                .templateIds(templateIds)
+        return MathResponseDTO.templateDto.builder()
+                .templates(templateDtos)
                 .build();
 
-        return dto;
-
 
     }
 
-    public String createParameter(Long mathId, Long templateId){
-
-        Math math=mathRepository.findById(mathId)
-                .orElseThrow(()->new TempHandler(MATH_NOT_FOUND));
-        String typePrompt=generateTemplatePrompt(mathId,templateId);
-        String response;
-        try{
-            response = callOpenAI(typePrompt, 500);
-        } catch (JsonProcessingException e) {
-            throw new TempHandler(JSON_PARSING_ERROR);
-        }
-        return response;
-
-    }
-
-    public String generateTemplatePrompt(Long mathId,Long templateId) {
-        StringBuilder prompt = new StringBuilder();
-        Math math=mathRepository.findById(mathId).orElseThrow(()->new TempHandler(MATH_NOT_FOUND));
-        String mathText=math.getProblem();
-        String mathType=math.getMathType().getTypeName();
-        Template template= templateRepository.findById(templateId).orElseThrow(()->new TempHandler(TEMPLATE_NOT_FOUND));
-        String gpt=template.getGpt();
-
-        prompt.append("문제:").append(mathText).append("\n")
-                .append("유형:").append(mathType).append("\n")
-                .append("1. 문제 텍스트와 유형은 위와 같아. 이 문제와 유형을 \n")
-                .append("2. 문제 텍스트와 문제 이미지를 보고 내가 보낸 유형 리스트 중에 해당하는 유형 이름을 추출해서 typeName에 붙여줘.\n")
-                .append("3. JSON은 반드시 아래 예시 형식으로 출력하고, 설명이나 추가 문장은 절대 쓰지 마.\n")
-                .append("4. 문제 정답도 구해주고 answer에 붙여줘.\n")
-                .append("5. 그리고 이 문제의 학년, 학기, 단원 제목도 알려줘.\n\n")
-                .append("6. 템플릿 어떤식으로 해야하는지 보내줄게.\n").append(gpt).append("\n\n")
-                .append("출력 형식 예시:\n")
-                .append("{\n")
-                .append("  \"problem\": \"2+3\",\n")
-                .append("  \"typeName\": \"apple\",\n")
-                .append("  \"answer\": 5,\n")
-                .append("  \"학년\": 3,\n")
-                .append("  \"학기\": 2,\n")
-                .append("  \"단원\": 1단원,\n")
-                .append("}\n\n")
-                .append("지금부터 이미지를 분석하고 위 JSON만 정확히 출력해. 그 외 설명은 쓰지 마.");
-
-        return prompt.toString();
-    }
 
 
 
-    public String callOpenAI(String prompt, int maxTokens) throws JsonProcessingException {
-        HttpHeaders headers = new HttpHeaders();
-        headers.setContentType(MediaType.APPLICATION_JSON);
-        headers.setBearerAuth(gptConfig.getSecretKey());
-
-        // OpenAI 메시지 구성
-        Map<String, Object> requestBody = new HashMap<>();
-        requestBody.put("model", gptConfig.getModel());
-
-        // messages 배열 구성 (system + user 역할)
-        requestBody.put("messages", new Object[]{
-                // system 역할: 답변 형식, 스타일 설정
-                new HashMap<String, String>() {{
-                    put("role", "system");
-                    put("content", String.format(
-                            "You are an assistant that returns only JSON responses. " +
-                                    "Do not explain. Only output valid JSON according to the user's prompt."));
-                }},
-                // user 역할: 실제 prompt 입력
-                new HashMap<String, String>() {{
-                    put("role", "user");
-                    put("content", prompt);
-                }}
-        });
-
-
-        // 기타 설정
-        requestBody.put("temperature", 0.3);
-        requestBody.put("max_tokens", maxTokens);
-
-        // HTTP 요청 생성
-        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
-
-        try {
-            ResponseEntity<String> response = restTemplate.exchange(
-                    "https://api.openai.com/v1/chat/completions", HttpMethod.POST, entity, String.class);
-            return response.getBody();
-        } catch (Exception e) {
-            return "Error: " + e.getMessage();
-        }
-    }
 }

--- a/src/main/java/cap/math/service/TemplateService/TemplateServiceImpl.java
+++ b/src/main/java/cap/math/service/TemplateService/TemplateServiceImpl.java
@@ -1,9 +1,11 @@
 package cap.math.service.TemplateService;
 
 import cap.math.apiPayload.exception.handler.TempHandler;
+import cap.math.domain.Math;
 import cap.math.domain.MathType;
 import cap.math.domain.UnitTemplateMapping;
 import cap.math.dto.math.MathResponseDTO;
+import cap.math.repository.MathRepository;
 import cap.math.repository.MathTypeRepository;
 import cap.math.repository.UnitTemplateMappingRepository;
 import cap.math.service.MathService.MathService;
@@ -13,6 +15,7 @@ import org.springframework.stereotype.Service;
 import java.util.List;
 import java.util.stream.Collectors;
 
+import static cap.math.apiPayload.code.status.ErrorStatus.MATH_NOT_FOUND;
 import static cap.math.apiPayload.code.status.ErrorStatus.TYPE_NOT_FOUND;
 
 @Service
@@ -20,6 +23,7 @@ import static cap.math.apiPayload.code.status.ErrorStatus.TYPE_NOT_FOUND;
 public class TemplateServiceImpl implements TemplateService {
     private final MathTypeRepository mathTypeRepository;
     private final UnitTemplateMappingRepository unitTemplateMappingRepository;
+    private final MathRepository mathRepository;
 
 
     public MathResponseDTO.templateDto getTemplateList(String typeName){
@@ -40,6 +44,13 @@ public class TemplateServiceImpl implements TemplateService {
 
         return dto;
 
+
+    }
+
+    public MathResponseDTO.createParameterDto createParameter(Long mathId, Long templateId){
+
+        Math math=mathRepository.findById(mathId)
+                .orElseThrow(()->new TempHandler(MATH_NOT_FOUND));
 
     }
 }

--- a/src/main/java/cap/math/service/TemplateService/TemplateServiceImpl.java
+++ b/src/main/java/cap/math/service/TemplateService/TemplateServiceImpl.java
@@ -1,22 +1,33 @@
 package cap.math.service.TemplateService;
 
 import cap.math.apiPayload.exception.handler.TempHandler;
+import cap.math.config.GptConfig;
+import cap.math.domain.*;
 import cap.math.domain.Math;
-import cap.math.domain.MathType;
-import cap.math.domain.UnitTemplateMapping;
 import cap.math.dto.math.MathResponseDTO;
 import cap.math.repository.MathRepository;
 import cap.math.repository.MathTypeRepository;
+import cap.math.repository.TemplateRepository;
 import cap.math.repository.UnitTemplateMappingRepository;
 import cap.math.service.MathService.MathService;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.*;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.multipart.MultipartFile;
 
+import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 
-import static cap.math.apiPayload.code.status.ErrorStatus.MATH_NOT_FOUND;
-import static cap.math.apiPayload.code.status.ErrorStatus.TYPE_NOT_FOUND;
+import static cap.math.apiPayload.code.status.ErrorStatus.*;
+import static cap.math.apiPayload.code.status.ErrorStatus._BAD_REQUEST;
 
 @Service
 @RequiredArgsConstructor
@@ -24,6 +35,9 @@ public class TemplateServiceImpl implements TemplateService {
     private final MathTypeRepository mathTypeRepository;
     private final UnitTemplateMappingRepository unitTemplateMappingRepository;
     private final MathRepository mathRepository;
+    private final TemplateRepository templateRepository;
+    private final GptConfig gptConfig;
+    private final RestTemplate restTemplate;
 
 
     public MathResponseDTO.templateDto getTemplateList(String typeName){
@@ -47,10 +61,92 @@ public class TemplateServiceImpl implements TemplateService {
 
     }
 
-    public MathResponseDTO.createParameterDto createParameter(Long mathId, Long templateId){
+    public String createParameter(Long mathId, Long templateId){
 
         Math math=mathRepository.findById(mathId)
                 .orElseThrow(()->new TempHandler(MATH_NOT_FOUND));
+        String typePrompt=generateTemplatePrompt(mathId,templateId);
+        String response;
+        try{
+            response = callOpenAI(typePrompt, 500);
+        } catch (JsonProcessingException e) {
+            throw new TempHandler(JSON_PARSING_ERROR);
+        }
+        return response;
 
+    }
+
+    public String generateTemplatePrompt(Long mathId,Long templateId) {
+        StringBuilder prompt = new StringBuilder();
+        Math math=mathRepository.findById(mathId).orElseThrow(()->new TempHandler(MATH_NOT_FOUND));
+        String mathText=math.getProblem();
+        String mathType=math.getMathType().getTypeName();
+        Template template= templateRepository.findById(templateId).orElseThrow(()->new TempHandler(TEMPLATE_NOT_FOUND));
+        String gpt=template.getGpt();
+
+        prompt.append("문제:").append(mathText).append("\n")
+                .append("유형:").append(mathType).append("\n")
+                .append("1. 문제 텍스트와 유형은 위와 같아. 이 문제와 유형을 \n")
+                .append("2. 문제 텍스트와 문제 이미지를 보고 내가 보낸 유형 리스트 중에 해당하는 유형 이름을 추출해서 typeName에 붙여줘.\n")
+                .append("3. JSON은 반드시 아래 예시 형식으로 출력하고, 설명이나 추가 문장은 절대 쓰지 마.\n")
+                .append("4. 문제 정답도 구해주고 answer에 붙여줘.\n")
+                .append("5. 그리고 이 문제의 학년, 학기, 단원 제목도 알려줘.\n\n")
+                .append("6. 템플릿 어떤식으로 해야하는지 보내줄게.\n").append(gpt).append("\n\n")
+                .append("출력 형식 예시:\n")
+                .append("{\n")
+                .append("  \"problem\": \"2+3\",\n")
+                .append("  \"typeName\": \"apple\",\n")
+                .append("  \"answer\": 5,\n")
+                .append("  \"학년\": 3,\n")
+                .append("  \"학기\": 2,\n")
+                .append("  \"단원\": 1단원,\n")
+                .append("}\n\n")
+                .append("지금부터 이미지를 분석하고 위 JSON만 정확히 출력해. 그 외 설명은 쓰지 마.");
+
+        return prompt.toString();
+    }
+
+
+
+    public String callOpenAI(String prompt, int maxTokens) throws JsonProcessingException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        headers.setBearerAuth(gptConfig.getSecretKey());
+
+        // OpenAI 메시지 구성
+        Map<String, Object> requestBody = new HashMap<>();
+        requestBody.put("model", gptConfig.getModel());
+
+        // messages 배열 구성 (system + user 역할)
+        requestBody.put("messages", new Object[]{
+                // system 역할: 답변 형식, 스타일 설정
+                new HashMap<String, String>() {{
+                    put("role", "system");
+                    put("content", String.format(
+                            "You are an assistant that returns only JSON responses. " +
+                                    "Do not explain. Only output valid JSON according to the user's prompt."));
+                }},
+                // user 역할: 실제 prompt 입력
+                new HashMap<String, String>() {{
+                    put("role", "user");
+                    put("content", prompt);
+                }}
+        });
+
+
+        // 기타 설정
+        requestBody.put("temperature", 0.3);
+        requestBody.put("max_tokens", maxTokens);
+
+        // HTTP 요청 생성
+        HttpEntity<Map<String, Object>> entity = new HttpEntity<>(requestBody, headers);
+
+        try {
+            ResponseEntity<String> response = restTemplate.exchange(
+                    "https://api.openai.com/v1/chat/completions", HttpMethod.POST, entity, String.class);
+            return response.getBody();
+        } catch (Exception e) {
+            return "Error: " + e.getMessage();
+        }
     }
 }

--- a/src/main/java/cap/math/service/TemplateService/TemplateServiceImpl.java
+++ b/src/main/java/cap/math/service/TemplateService/TemplateServiceImpl.java
@@ -1,0 +1,45 @@
+package cap.math.service.TemplateService;
+
+import cap.math.apiPayload.exception.handler.TempHandler;
+import cap.math.domain.MathType;
+import cap.math.domain.UnitTemplateMapping;
+import cap.math.dto.math.MathResponseDTO;
+import cap.math.repository.MathTypeRepository;
+import cap.math.repository.UnitTemplateMappingRepository;
+import cap.math.service.MathService.MathService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static cap.math.apiPayload.code.status.ErrorStatus.TYPE_NOT_FOUND;
+
+@Service
+@RequiredArgsConstructor
+public class TemplateServiceImpl implements TemplateService {
+    private final MathTypeRepository mathTypeRepository;
+    private final UnitTemplateMappingRepository unitTemplateMappingRepository;
+
+
+    public MathResponseDTO.templateDto getTemplateList(String typeName){
+        MathType mathType=mathTypeRepository.findByTypeName(typeName)
+                .orElseThrow(() -> new TempHandler(TYPE_NOT_FOUND));
+
+        List<UnitTemplateMapping> unitTemplateMappings=unitTemplateMappingRepository.findAllByMathType(mathType);
+
+        //UnitTemplateMapping에서 id 리스트를 dto에 담기.
+        List<Long> templateIds = unitTemplateMappings.stream()
+                .map(mapping -> mapping.getTemplate().getId())
+                .collect(Collectors.toList());
+
+        // DTO 객체 생성 후 값 세팅
+        MathResponseDTO.templateDto dto =  MathResponseDTO.templateDto.builder()
+                .templateIds(templateIds)
+                .build();
+
+        return dto;
+
+
+    }
+}


### PR DESCRIPTION
## 🔀 Pull Request Title
> 간결하고 명확한 제목 작성 / 관련 있는 이슈 번호를 함께 작성 (예: `[feat#1] 로그인 기능 구현`)
<!-- 띄어쓰기 -->
- 아래 이슈번호 작성
<!-- 띄어쓰기 -->
close #48 
---

## 📌 PR 설명
> 이번 PR에서 어떤 작업을 했는지 요약해주세요.
<!-- 띄어쓰기 -->
### 문제 유형 분류 API
- 프롬포트 수정
- DB에 모든 유형 정보 저장
- 테스트 완료 (물의 양 비교 문제로 테스트)

### 컨텐츠 리스트 조회 API
- response 값 수정
   - template name, template image, template이 가능한지 boolean 값
 
### 컨텐츠 파라미터 추출 API
- 프롬포트 수정
- gpt에게 받아온 JSON데이터 형식 그대로 DB에 저장하도록 로직 수정
- 사과 덧셈 프롬포트 작성 후, DB에 저장
- 사과 덧셈 프롬포트로 테스트 완료
---

## 📷 스크린샷 (if applicable)
> 스크린샷이 필요한 과제면 스크린샷을 첨부해주세요
<!-- 띄어쓰기 -->
### 문제 유형 분류 API - gpt 프롬포트
<img width="1894" height="581" alt="image" src="https://github.com/user-attachments/assets/d9de28f2-7340-4a27-a041-2e7100bccfa1" />

### 파라미터 추출 API - gpt 프롬포트
<img width="984" height="189" alt="image" src="https://github.com/user-attachments/assets/f3a12dc7-02f6-4d0a-bdb6-b031692f09e9" />

---

## 🔍 추가 설명
> 리뷰어가 알아야 할 추가 정보나 요청사항이 있다면 적어주세요.
<!-- 띄어쓰기 -->
